### PR TITLE
Add optional chunk param to split function

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,5 +72,6 @@ module.exports = {
   pageInfo,
   mediaBox,
   crop: cropBox,
-  cropBox
+  cropBox,
+  cpdf
 };

--- a/index.js
+++ b/index.js
@@ -15,8 +15,9 @@ function merge(filePaths, output) {
   .then(() => output);
 }
 
-function split(filePath, dest) {
-  return cpdf('Splitting', `-split ${filePath} -o ${dest}`);
+function split(filePath, dest, chunks = null) {
+  const chunkFlag = (chunks == null) ? '' : `-chunk ${chunks}`
+  return cpdf('Splitting', `-split ${filePath} -o ${dest} ${chunkFlag}`);
 }
 
 function write(blankFile, args, output) {


### PR DESCRIPTION
Hi, 

Thanks for your work with this repo!

- I need to use the `-chunk` flag described [here](https://www.coherentpdf.com/cpdfmanual/cpdfmanualch2.html#x5-240002.2) so I added it as an optional parameter.

- Also given the fact that the `cpdf` function works well, I propose exporting it so that developers can use it to run commands that are not yet supported by this driver.

